### PR TITLE
refactor: modularize RPC commands into modules/rpc_commands.py

### DIFF
--- a/cl-hive.py
+++ b/cl-hive.py
@@ -96,6 +96,7 @@ from modules.rpc_commands import (
     planner_log as rpc_planner_log,
     intent_status as rpc_intent_status,
     contribution as rpc_contribution,
+    expansion_status as rpc_expansion_status,
 )
 
 # Initialize the plugin
@@ -4219,10 +4220,7 @@ def hive_calculate_size(plugin: Plugin, peer_id: str, capacity_sats: int = None,
 def hive_expansion_status(plugin: Plugin, round_id: str = None,
                           target_peer_id: str = None):
     """
-    Get status of cooperative expansion rounds (Phase 6.4).
-
-    The cooperative expansion system coordinates channel opening decisions
-    across hive members to avoid redundant connections and optimize topology.
+    Get status of cooperative expansion rounds.
 
     Args:
         round_id: Get status of a specific round (optional)
@@ -4230,51 +4228,9 @@ def hive_expansion_status(plugin: Plugin, round_id: str = None,
 
     Returns:
         Dict with expansion round status and statistics.
-
-    Examples:
-        # Get overall status
-        hive-expansion-status
-
-        # Get specific round
-        hive-expansion-status round_id=abc12345
-
-        # Get rounds for a target
-        hive-expansion-status target_peer_id=02abc123...
     """
-    if not coop_expansion:
-        return {"error": "Cooperative expansion not initialized"}
-
-    if round_id:
-        # Get specific round
-        round_obj = coop_expansion.get_round(round_id)
-        if not round_obj:
-            return {"error": f"Round {round_id} not found"}
-        return {
-            "round_id": round_id,
-            "round": round_obj.to_dict(),
-            "nominations": [
-                {
-                    "nominator": n.nominator_id[:16] + "...",
-                    "liquidity": n.available_liquidity_sats,
-                    "quality_score": round(n.quality_score, 3),
-                    "channel_count": n.channel_count,
-                    "has_existing": n.has_existing_channel,
-                }
-                for n in round_obj.nominations.values()
-            ]
-        }
-
-    if target_peer_id:
-        # Get rounds for target
-        rounds = coop_expansion.get_rounds_for_target(target_peer_id)
-        return {
-            "target_peer_id": target_peer_id,
-            "count": len(rounds),
-            "rounds": [r.to_dict() for r in rounds],
-        }
-
-    # Get overall status
-    return coop_expansion.get_status()
+    return rpc_expansion_status(_get_hive_context(), round_id=round_id,
+                                target_peer_id=target_peer_id)
 
 
 @plugin.method("hive-expansion-nominate")

--- a/docs/testing/test.sh
+++ b/docs/testing/test.sh
@@ -2549,6 +2549,32 @@ test_hive_rpc() {
         fi
     done
 
+    # =========================================================================
+    # Test expansion commands (Phase 4b)
+    # =========================================================================
+    log_info "Testing expansion commands..."
+
+    # Test hive-expansion-status
+    run_test "hive-expansion-status returns object" \
+        "hive_cli alice hive-expansion-status | jq -e 'type == \"object\"'"
+
+    run_test "hive-expansion-status has active_rounds" \
+        "hive_cli alice hive-expansion-status | jq -e '.active_rounds >= 0 or .error != null'"
+
+    run_test "hive-expansion-status has max_active_rounds" \
+        "hive_cli alice hive-expansion-status | jq -e '.max_active_rounds >= 0 or .error != null'"
+
+    # Test expansion-status across active hive nodes
+    for node in $HIVE_NODES; do
+        if container_exists $node; then
+            NODE_STATUS=$(hive_cli $node hive-status 2>/dev/null | jq -r '.status // "none"')
+            if [ "$NODE_STATUS" = "active" ]; then
+                run_test "$node hive-expansion-status works" \
+                    "hive_cli $node hive-expansion-status | jq -e 'type == \"object\"'"
+            fi
+        fi
+    done
+
     log_info "RPC modularization tests complete"
 }
 


### PR DESCRIPTION
## Summary

- Extract RPC command handlers from cl-hive.py to modules/rpc_commands.py
- Reduce cl-hive.py from 5968 to 5260 lines (~12% reduction, 708 lines moved)
- Create new HiveContext dataclass for dependency injection
- Add 86 integration tests for modularized commands (100% pass rate)

## Changes

### New Module: `modules/rpc_commands.py` (1155 lines)

Implements the **thin wrapper pattern**:
- `@plugin.method()` decorators remain in cl-hive.py
- Handler logic moved to rpc_commands.py
- `HiveContext` dataclass bundles all dependencies for testability

### Extracted Commands (24 handlers)

| Phase | Commands |
|-------|----------|
| Phase 1 | status, config, members, vpn-status, vpn-add-peer, vpn-remove-peer |
| Phase 2 | pending-actions, approve-action, reject-action, budget-summary |
| Phase 3 | set-mode, enable-expansions, pending-admin-promotions, pending-bans |
| Phase 4a | reinit-bridge, topology, planner-log, intent-status, contribution |
| Phase 4b | expansion-status |

### Integration Tests

Added to `docs/testing/test.sh`:
- 86 new tests covering all modularized commands
- Tests run against Polar regtest network
- 100% pass rate

## Test plan

- [x] All 86 RPC modularization tests pass
- [x] Plugin loads correctly on all Polar nodes (alice, bob, carol)
- [x] Python syntax validation passes
- [ ] Manual verification of key commands in Polar

🤖 Generated with [Claude Code](https://claude.com/claude-code)