### PR TITLE
fix(mcp): add health check, parallel calls, and watchdog

### DIFF
--- a/tools/hive-watchdog.sh
+++ b/tools/hive-watchdog.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# hive-watchdog.sh - Monitor and auto-restart hung cl-hive plugins
+# Run via cron: */15 * * * * /home/sat/bin/cl-hive/tools/hive-watchdog.sh
+
+set -euo pipefail
+
+NODES_CONFIG="${HIVE_NODES_CONFIG:-/home/sat/bin/cl-hive/production/nodes.production.json}"
+LOG_FILE="/tmp/hive-watchdog.log"
+TIMEOUT=10
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+check_and_restart_plugin() {
+    local node_name="$1"
+    local rest_url="$2"
+    local rune="$3"
+    local plugin_path="$4"
+    
+    # Test hive-status with timeout
+    response=$(timeout "$TIMEOUT" curl -sk -X POST \
+        -H "Rune: $rune" \
+        -H "Content-Type: application/json" \
+        -d '{}' \
+        "${rest_url}/v1/hive-status" 2>&1) || response="TIMEOUT"
+    
+    if [[ "$response" == "TIMEOUT" ]] || [[ "$response" == *"error"* && "$response" != *"governance_mode"* ]]; then
+        log "WARNING: $node_name hive-status failed, restarting plugin..."
+        
+        # Stop plugin
+        timeout 15 curl -sk -X POST \
+            -H "Rune: $rune" \
+            -H "Content-Type: application/json" \
+            -d "{\"subcommand\": \"stop\", \"plugin\": \"$plugin_path\"}" \
+            "${rest_url}/v1/plugin" 2>/dev/null || true
+        
+        sleep 2
+        
+        # Start plugin
+        restart_result=$(timeout 15 curl -sk -X POST \
+            -H "Rune: $rune" \
+            -H "Content-Type: application/json" \
+            -d "{\"subcommand\": \"start\", \"plugin\": \"$plugin_path\"}" \
+            "${rest_url}/v1/plugin" 2>&1) || restart_result="FAILED"
+        
+        if [[ "$restart_result" == *"active\":true"* ]]; then
+            log "OK: $node_name plugin restarted successfully"
+        else
+            log "ERROR: $node_name plugin restart failed: $restart_result"
+        fi
+    else
+        log "OK: $node_name healthy"
+    fi
+}
+
+# Main
+log "=== Hive Watchdog Check ==="
+
+if [[ ! -f "$NODES_CONFIG" ]]; then
+    log "ERROR: Config not found: $NODES_CONFIG"
+    exit 1
+fi
+
+# Parse nodes config and check each
+# Note: Adjust plugin paths per node as needed
+jq -r '.nodes[] | "\(.name)|\(.rest_url)|\(.rune)"' "$NODES_CONFIG" | while IFS='|' read -r name url rune; do
+    # Determine plugin path based on node
+    if [[ "$name" == "hive-nexus-01" ]]; then
+        plugin_path="/data/lightningd/plugins/cl-hive/cl-hive.py"
+    else
+        plugin_path="/opt/cl-hive/cl-hive.py"
+    fi
+    
+    check_and_restart_plugin "$name" "$url" "$rune" "$plugin_path"
+done
+
+log "=== Watchdog Complete ==="


### PR DESCRIPTION
## Summary

Improves MCP server robustness when nodes become unresponsive.

## Changes

### 1. Health Check Endpoint (`hive_health`)
- Lightweight connectivity test using `getinfo`
- Returns status, latency, alias, blockheight per node
- 5s default timeout (configurable)

### 2. Parallel Node Calls
- `call_all()` now uses `asyncio.gather()`
- Each node has independent timeout
- One hung node no longer blocks others

### 3. Watchdog Script (`hive-watchdog.sh`)
- Monitors `hive-status` on all nodes
- Auto-restarts cl-hive plugin if unresponsive
- Designed for cron: `*/15 * * * *`

## Testing

```bash
mcporter call hive.hive_health
mcporter call hive.hive_status
./tools/hive-watchdog.sh
```

## Context

Had an incident where cl-hive plugins became unresponsive, causing all MCP queries to timeout. These changes ensure fast detection, graceful degradation, and automatic recovery.