### PR TITLE
fix(mcp): allow numeric/boolean values in revenue_config schema

### DIFF
--- a/tools/mcp-hive-server.py
+++ b/tools/mcp-hive-server.py
@@ -1376,7 +1376,7 @@ Fee targets: stagnant=50ppm, depleted=150-250ppm, active underwater=100-600ppm, 
                         "description": "Configuration key (for get/set/reset)"
                     },
                     "value": {
-                        "type": "string",
+                        "type": ["string", "number", "boolean"],
                         "description": "New value (for set action)"
                     }
                 },


### PR DESCRIPTION
Fixes #46

Changed `value` parameter type from `"string"` to `["string", "number", "boolean"]` in the revenue_config tool schema.

This allows mcporter to pass numeric values like `min_fee_ppm=25` without type validation errors.