### PR TITLE
docs: add hive node addresses and contact info for new members

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ Optional WireGuard VPN integration for secure fleet communication.
 | `autonomous` | Execute actions automatically within strict safety bounds |
 | `oracle` | Delegate decisions to external API |
 
+## Join the Lightning Hive
+
+Want to join an existing hive fleet? The Lightning Hive is actively accepting new members.
+
+**Current Hive Nodes:**
+
+| Node | Connection |
+|------|------------|
+| ⚡Lightning Goats CLN⚡ | `0382d558331b9a0c1d141f56b71094646ad6111e34e197d47385205019b03afdc3@45.76.234.192:9735` |
+| Hive-Nexus-02 | `03fe48e8a64f14fa0aa7d9d16500754b3b906c729acfb867c00423fd4b0b9b56c2@45.76.234.192:9736` |
+
+**To join:**
+1. Run your own CLN node with cl-hive
+2. Request an invite ticket via [Nostr](https://njump.me/hex@lightning-goats.com) or [GitHub Issues](https://github.com/lightning-goats/cl-hive/issues)
+3. Open a channel to a hive member (skin in the game)
+4. Use the ticket to join as a neophyte
+5. Get vouched by existing members for full membership
+
+See [Joining the Hive](docs/JOINING_THE_HIVE.md) for the complete guide.
+
 ## Installation
 
 ### Prerequisites

--- a/docs/JOINING_THE_HIVE.md
+++ b/docs/JOINING_THE_HIVE.md
@@ -73,7 +73,16 @@ lightning-cli hive-invite
 
 | Node | Connection String |
 |------|-------------------|
-| Hive-Nexus-01 | `0382d558331b9a0c1d141f56b71094646ad6111e34e197d47385205019b03afdc3@45.76.234.192:9735` |
+| ⚡Lightning Goats CLN⚡ (nexus-01) | `0382d558331b9a0c1d141f56b71094646ad6111e34e197d47385205019b03afdc3@45.76.234.192:9735` |
+| Hive-Nexus-02 | `03fe48e8a64f14fa0aa7d9d16500754b3b906c729acfb867c00423fd4b0b9b56c2@45.76.234.192:9736` |
+
+**Tor (onion) addresses:**
+- nexus-01: `xsp4whqtphjnby335a3ihtje55gidhf4pnv3blrgustplyxfnpsgeuyd.onion:9735`
+- nexus-02: `vxykasr6vdl77ph6hvo4a3mxfj2wbirwujdyrg4scowuhix7pp53l7yd.onion:9736`
+
+**To request an invite ticket:**
+- Nostr: `hex@lightning-goats.com` (npub1qkjnsgk6zrszkmk2c7ywycvh46ylp3kw4kud8y8a20m93y5synvqewl0sq)
+- GitHub: Open an issue at https://github.com/lightning-goats/cl-hive/issues
 
 You can also find active members via Lightning network explorers or community channels.
 


### PR DESCRIPTION
Makes it easier for new nodes to join the hive by adding:

## README.md
- New "Join the Lightning Hive" section with both node connection strings
- Quick steps to join
- Link to full guide

## docs/JOINING_THE_HIVE.md  
- Added nexus-02 connection string
- Added Tor onion addresses for both nodes
- Added contact info (Nostr: hex@lightning-goats.com, GitHub Issues)

This gives prospective members a clear path to request invite tickets and connect to the fleet.