### PR TITLE
feat(docker): Add trustedcoin support 

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -113,6 +113,26 @@ WIREGUARD_CONFIG_PATH=./wireguard
 HIVE_GOVERNANCE_MODE=advisor
 
 # =============================================================================
+# TRUSTEDCOIN (OPTIONAL - Alternative Bitcoin Backend)
+# =============================================================================
+# Trustedcoin replaces the bcli plugin, using block explorers instead of/alongside bitcoind.
+# Useful for VPS deployments without local Bitcoin Core node.
+#
+# MODES:
+#   Explorer-only: Set TRUSTEDCOIN_ENABLED=true and leave BITCOIN_RPC* empty
+#                  Uses public explorers (mempool.space, blockstream.info, etc.)
+#                  No bitcoind required - perfect for lightweight VPS deployments
+#
+#   Hybrid:        Set TRUSTEDCOIN_ENABLED=true WITH BITCOIN_RPC* configured
+#                  Uses bitcoind as primary, falls back to explorers if bitcoind fails
+#                  Best reliability - recommended for production with bitcoind access
+#
+# SECURITY NOTE: Explorer-only mode trusts third-party block explorers.
+#                For maximum security, use hybrid mode or standard bcli with local bitcoind.
+
+TRUSTEDCOIN_ENABLED=false
+
+# =============================================================================
 # EXPERIMENTAL FEATURES
 # =============================================================================
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -155,6 +155,24 @@ RUN git clone --depth 1 https://github.com/ksedgwic/clboss.git \
     && rm -rf clboss
 
 # =============================================================================
+# TRUSTEDCOIN PLUGIN (OPTIONAL)
+# =============================================================================
+# Trustedcoin replaces bcli for Bitcoin backend, using block explorers.
+# Useful for VPS deployments without local bitcoind.
+# - Explorer-only mode: No bitcoind required, uses public explorers
+# - Hybrid mode: bitcoind primary with explorer fallback
+
+ARG TRUSTEDCOIN_VERSION=v0.8.6
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then ARCH="linux-amd64"; fi \
+    && if [ "$ARCH" = "aarch64" ]; then ARCH="linux-arm64"; fi \
+    && wget -O /tmp/trustedcoin.tar.gz "https://github.com/nbd-wtf/trustedcoin/releases/download/${TRUSTEDCOIN_VERSION}/trustedcoin-${TRUSTEDCOIN_VERSION}-${ARCH}.tar.gz" \
+    && tar -xzf /tmp/trustedcoin.tar.gz -C /tmp \
+    && mv /tmp/trustedcoin /usr/local/bin/trustedcoin \
+    && chmod +x /usr/local/bin/trustedcoin \
+    && rm /tmp/trustedcoin.tar.gz
+
+# =============================================================================
 # SLING PLUGIN (REQUIRED)
 # =============================================================================
 # Sling provides rebalancing capabilities required by cl-revenue-ops.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -89,6 +89,11 @@ services:
       # CLBOSS (optional - set to false to disable)
       - CLBOSS_ENABLED=${CLBOSS_ENABLED:-true}
 
+      # Trustedcoin (optional - alternative Bitcoin backend using block explorers)
+      # When enabled without bitcoin-rpc*: explorer-only mode (no bitcoind needed)
+      # When enabled with bitcoin-rpc*: hybrid mode (bitcoind primary, explorers fallback)
+      - TRUSTEDCOIN_ENABLED=${TRUSTEDCOIN_ENABLED:-false}
+
       # Logging
       - LOG_LEVEL=${LOG_LEVEL:-info}
 


### PR DESCRIPTION
feat(docker): Add trustedcoin support for explorer-only and hybrid Bitcoin backends

- Add trustedcoin v0.8.6 binary to Docker image (x86_64 + ARM64)
- New TRUSTEDCOIN_ENABLED env var (default: false, backward compatible)
- Explorer-only mode: runs without bitcoind using public block explorers
- Hybrid mode: bitcoind primary with automatic explorer fallback
- Update entrypoint to configure trustedcoin when enabled
- Update README with usage documentation and security considerations

Useful for VPS deployments without local bitcoind or for resilience against bitcoind downtime.