### PR TITLE
Protocol hardening: version tolerance + deterministic idempotency

### DIFF
--- a/modules/handshake.py
+++ b/modules/handshake.py
@@ -546,7 +546,11 @@ class HandshakeManager:
                 features.append('onion-msg')
         except Exception:
             pass
-        
+
+        # Advertise max supported protocol version (Phase B hardening)
+        from modules.protocol import SUPPORTED_VERSIONS
+        features.append(f'proto-v{max(SUPPORTED_VERSIONS)}')
+
         return features
     
     def check_requirements(self, requirements: int, features: list) -> Tuple[bool, list]:

--- a/modules/idempotency.py
+++ b/modules/idempotency.py
@@ -1,0 +1,87 @@
+"""
+Idempotency module for cl-hive (Phase C hardening).
+
+Provides deterministic event ID generation and check-and-record helpers
+for state-changing protocol messages. Ensures that restarted nodes do not
+re-process messages already handled before the restart.
+
+Design:
+- Each message family declares its identity fields in EVENT_ID_FIELDS.
+- generate_event_id() produces a stable SHA-256 hash from those fields.
+- check_and_record() wraps the DB insert with INSERT OR IGNORE semantics.
+- Gossip/state-hash/intelligence snapshots are excluded (overwrite-based).
+"""
+
+import hashlib
+import json
+from typing import Any, Dict, Optional, Tuple
+
+
+# Maps message type name -> list of payload fields that form the stable
+# event identity.  Order matters for deterministic hashing.
+EVENT_ID_FIELDS: Dict[str, list] = {
+    # Phase 5: Membership
+    "PROMOTION_REQUEST": ["target_pubkey", "request_id"],
+    "VOUCH": ["target_pubkey", "request_id", "voucher_pubkey"],
+    "PROMOTION": ["target_pubkey", "request_id"],
+    "MEMBER_LEFT": ["peer_id", "timestamp"],
+    # Phase 5: Ban governance
+    "BAN_PROPOSAL": ["proposal_id"],
+    "BAN_VOTE": ["proposal_id", "voter_peer_id"],
+    # Phase 9: Fee reports
+    "FEE_REPORT": ["peer_id", "period_start"],
+    # Phase 12: Settlement
+    "SETTLEMENT_PROPOSE": ["proposal_id"],
+    "SETTLEMENT_READY": ["proposal_id", "voter_peer_id"],
+    "SETTLEMENT_EXECUTED": ["proposal_id", "executor_peer_id"],
+    # Phase 10: Task delegation
+    "TASK_REQUEST": ["request_id"],
+    "TASK_RESPONSE": ["request_id", "responder_id"],
+    # Phase 11: Splice coordination
+    "SPLICE_INIT_REQUEST": ["session_id"],
+    "SPLICE_UPDATE": ["session_id", "update_seq"],
+    "SPLICE_SIGNED": ["session_id"],
+    "SPLICE_ABORT": ["session_id"],
+}
+
+
+def generate_event_id(event_type: str, payload: Dict[str, Any]) -> Optional[str]:
+    """
+    Build a deterministic event ID from the message type and identity fields.
+
+    Returns:
+        32-char hex string, or None if no rules exist for event_type or
+        required fields are missing.
+    """
+    fields = EVENT_ID_FIELDS.get(event_type)
+    if not fields:
+        return None
+
+    identity = {"_type": event_type}
+    for f in fields:
+        val = payload.get(f)
+        if val is None:
+            return None
+        identity[f] = val
+
+    canonical = json.dumps(identity, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()[:32]
+
+
+def check_and_record(db, event_type: str, payload: Dict[str, Any],
+                     actor_id: str) -> Tuple[bool, Optional[str]]:
+    """
+    Generate event ID and atomically record it via the database.
+
+    Returns:
+        (is_new, event_id) where:
+        - (True, event_id)  -- first time seeing this event
+        - (False, event_id) -- duplicate, already recorded
+        - (True, None)      -- untracked message type (no rules)
+    """
+    event_id = generate_event_id(event_type, payload)
+    if event_id is None:
+        return (True, None)
+
+    is_new = db.record_proto_event(event_id, event_type, actor_id)
+    return (is_new, event_id)

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,249 @@
+"""
+Tests for Phase C: Deterministic idempotency.
+
+Covers:
+- generate_event_id() determinism and edge cases
+- check_and_record() new vs duplicate detection
+- Proto events cleanup
+- Relay generate_msg_id() _event_id preference
+
+Run with: pytest tests/test_idempotency.py -v
+"""
+
+import json
+import time
+import pytest
+import sys
+import os
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from modules.idempotency import (
+    EVENT_ID_FIELDS,
+    generate_event_id,
+    check_and_record,
+)
+from modules.database import HiveDatabase
+from modules.relay import RelayManager
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def db(tmp_path):
+    mock_plugin = Mock()
+    mock_plugin.log = Mock()
+    database = HiveDatabase(str(tmp_path / "test.db"), mock_plugin)
+    database.initialize()
+    return database
+
+
+# =============================================================================
+# generate_event_id() TESTS
+# =============================================================================
+
+class TestGenerateEventId:
+
+    def test_deterministic_same_inputs(self):
+        """Same inputs always produce the same event ID."""
+        payload = {"peer_id": "abc", "timestamp": 1234}
+        id1 = generate_event_id("MEMBER_LEFT", payload)
+        id2 = generate_event_id("MEMBER_LEFT", payload)
+        assert id1 == id2
+        assert len(id1) == 32
+
+    def test_different_types_different_ids(self):
+        """Different message types with overlapping fields produce different IDs."""
+        payload = {"target_pubkey": "abc", "request_id": "req1"}
+        id_promo_req = generate_event_id("PROMOTION_REQUEST", payload)
+        id_promo = generate_event_id("PROMOTION", payload)
+        assert id_promo_req != id_promo
+
+    def test_returns_none_for_untracked_type(self):
+        """Returns None for message types not in EVENT_ID_FIELDS."""
+        assert generate_event_id("GOSSIP", {"data": "test"}) is None
+        assert generate_event_id("STATE_HASH", {"hash": "abc"}) is None
+
+    def test_returns_none_when_fields_missing(self):
+        """Returns None when required fields are absent."""
+        # MEMBER_LEFT requires peer_id and timestamp
+        assert generate_event_id("MEMBER_LEFT", {"peer_id": "abc"}) is None
+        assert generate_event_id("MEMBER_LEFT", {"timestamp": 123}) is None
+        assert generate_event_id("MEMBER_LEFT", {}) is None
+
+    def test_extra_fields_ignored(self):
+        """Extra payload fields don't affect the event ID."""
+        base = {"peer_id": "abc", "timestamp": 1234}
+        extra = {"peer_id": "abc", "timestamp": 1234, "reason": "goodbye", "sig": "xyz"}
+        assert generate_event_id("MEMBER_LEFT", base) == generate_event_id("MEMBER_LEFT", extra)
+
+    def test_all_tracked_types_have_fields(self):
+        """Every entry in EVENT_ID_FIELDS has at least one field."""
+        for event_type, fields in EVENT_ID_FIELDS.items():
+            assert len(fields) > 0, f"{event_type} has no identity fields"
+
+    def test_ban_proposal_uses_proposal_id(self):
+        """BAN_PROPOSAL event ID is based on proposal_id."""
+        id1 = generate_event_id("BAN_PROPOSAL", {"proposal_id": "prop1"})
+        id2 = generate_event_id("BAN_PROPOSAL", {"proposal_id": "prop2"})
+        assert id1 != id2
+
+    def test_ban_vote_includes_voter(self):
+        """BAN_VOTE event ID includes voter_peer_id for uniqueness."""
+        id1 = generate_event_id("BAN_VOTE", {"proposal_id": "p1", "voter_peer_id": "v1"})
+        id2 = generate_event_id("BAN_VOTE", {"proposal_id": "p1", "voter_peer_id": "v2"})
+        assert id1 != id2
+
+    def test_vouch_includes_all_three_fields(self):
+        """VOUCH needs target, request_id, and voucher."""
+        payload = {"target_pubkey": "t", "request_id": "r", "voucher_pubkey": "v"}
+        eid = generate_event_id("VOUCH", payload)
+        assert eid is not None
+        # Missing one field
+        assert generate_event_id("VOUCH", {"target_pubkey": "t", "request_id": "r"}) is None
+
+    def test_settlement_types(self):
+        """Settlement message types produce valid event IDs."""
+        assert generate_event_id("SETTLEMENT_PROPOSE", {"proposal_id": "sp1"}) is not None
+        assert generate_event_id("SETTLEMENT_READY", {"proposal_id": "sp1", "voter_peer_id": "v1"}) is not None
+        assert generate_event_id("SETTLEMENT_EXECUTED", {"proposal_id": "sp1", "executor_peer_id": "e1"}) is not None
+
+
+# =============================================================================
+# check_and_record() TESTS
+# =============================================================================
+
+class TestCheckAndRecord:
+
+    def test_new_event_returns_true(self, db):
+        """First occurrence returns (True, event_id)."""
+        payload = {"peer_id": "abc", "timestamp": 1234}
+        is_new, event_id = check_and_record(db, "MEMBER_LEFT", payload, "abc")
+        assert is_new is True
+        assert event_id is not None
+        assert len(event_id) == 32
+
+    def test_duplicate_returns_false(self, db):
+        """Second occurrence of same event returns (False, event_id)."""
+        payload = {"peer_id": "abc", "timestamp": 1234}
+        is_new1, eid1 = check_and_record(db, "MEMBER_LEFT", payload, "abc")
+        is_new2, eid2 = check_and_record(db, "MEMBER_LEFT", payload, "abc")
+        assert is_new1 is True
+        assert is_new2 is False
+        assert eid1 == eid2
+
+    def test_untracked_type_returns_true_none(self, db):
+        """Untracked message type returns (True, None)."""
+        is_new, event_id = check_and_record(db, "GOSSIP", {"data": "test"}, "xyz")
+        assert is_new is True
+        assert event_id is None
+
+    def test_different_events_both_new(self, db):
+        """Different events are independently tracked."""
+        p1 = {"peer_id": "abc", "timestamp": 1000}
+        p2 = {"peer_id": "abc", "timestamp": 2000}
+        is_new1, _ = check_and_record(db, "MEMBER_LEFT", p1, "abc")
+        is_new2, _ = check_and_record(db, "MEMBER_LEFT", p2, "abc")
+        assert is_new1 is True
+        assert is_new2 is True
+
+    def test_has_proto_event(self, db):
+        """has_proto_event returns True after recording."""
+        payload = {"proposal_id": "ban1"}
+        _, event_id = check_and_record(db, "BAN_PROPOSAL", payload, "peer1")
+        assert db.has_proto_event(event_id) is True
+        assert db.has_proto_event("nonexistent") is False
+
+
+# =============================================================================
+# CLEANUP TESTS
+# =============================================================================
+
+class TestCleanup:
+
+    def test_cleanup_prunes_old_events(self, db):
+        """cleanup_proto_events removes entries older than threshold."""
+        # Insert an event manually with old timestamp
+        conn = db._get_connection()
+        old_time = int(time.time()) - 60 * 86400  # 60 days ago
+        conn.execute(
+            "INSERT INTO proto_events (event_id, event_type, actor_id, created_at, received_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("old_event", "MEMBER_LEFT", "peer1", old_time, old_time)
+        )
+        # Insert a recent event
+        recent_time = int(time.time())
+        conn.execute(
+            "INSERT INTO proto_events (event_id, event_type, actor_id, created_at, received_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("recent_event", "MEMBER_LEFT", "peer2", recent_time, recent_time)
+        )
+
+        pruned = db.cleanup_proto_events(max_age_seconds=30 * 86400)
+        assert pruned == 1  # Only old event pruned
+
+        assert db.has_proto_event("old_event") is False
+        assert db.has_proto_event("recent_event") is True
+
+    def test_cleanup_returns_zero_when_nothing_to_prune(self, db):
+        """cleanup_proto_events returns 0 when no old events exist."""
+        payload = {"peer_id": "abc", "timestamp": 1234}
+        check_and_record(db, "MEMBER_LEFT", payload, "abc")
+        pruned = db.cleanup_proto_events(max_age_seconds=30 * 86400)
+        assert pruned == 0
+
+
+# =============================================================================
+# RELAY generate_msg_id() TESTS
+# =============================================================================
+
+class TestRelayEventIdPreference:
+
+    @pytest.fixture
+    def relay_mgr(self):
+        return RelayManager(
+            our_pubkey="our_pk",
+            send_message=Mock(),
+            get_members=Mock(return_value=[]),
+        )
+
+    def test_uses_event_id_when_present(self, relay_mgr):
+        """generate_msg_id returns _event_id directly when present."""
+        payload = {
+            "peer_id": "abc",
+            "timestamp": 1234,
+            "_event_id": "a" * 32,
+        }
+        assert relay_mgr.generate_msg_id(payload) == "a" * 32
+
+    def test_fallback_when_no_event_id(self, relay_mgr):
+        """generate_msg_id hashes payload when _event_id absent."""
+        payload = {"peer_id": "abc", "timestamp": 1234}
+        msg_id = relay_mgr.generate_msg_id(payload)
+        assert len(msg_id) == 32
+        assert msg_id != "a" * 32
+
+    def test_ignores_short_event_id(self, relay_mgr):
+        """generate_msg_id ignores _event_id that's too short."""
+        payload = {
+            "peer_id": "abc",
+            "timestamp": 1234,
+            "_event_id": "tooshort",
+        }
+        msg_id = relay_mgr.generate_msg_id(payload)
+        assert msg_id != "tooshort"
+
+    def test_excludes_internal_fields_from_hash(self, relay_mgr):
+        """_envelope_version and _event_id don't affect hash fallback."""
+        payload1 = {"peer_id": "abc", "timestamp": 1234}
+        payload2 = {
+            "peer_id": "abc",
+            "timestamp": 1234,
+            "_envelope_version": 2,
+            "_event_id": "not32chars",  # won't be used (too short)
+        }
+        # Both should produce the same hash because internal fields are excluded
+        assert relay_mgr.generate_msg_id(payload1) == relay_mgr.generate_msg_id(payload2)

--- a/tests/test_protocol_versioning.py
+++ b/tests/test_protocol_versioning.py
@@ -1,0 +1,198 @@
+"""
+Tests for Phase B: Protocol version tolerance.
+
+Ensures deserialize() accepts a range of versions, rejects out-of-range
+versions, and that create_hello() advertises supported_versions.
+
+Run with: pytest tests/test_protocol_versioning.py -v
+"""
+
+import json
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from modules.protocol import (
+    HIVE_MAGIC,
+    PROTOCOL_VERSION,
+    SUPPORTED_VERSIONS,
+    MIN_SUPPORTED_VERSION,
+    MAX_SUPPORTED_VERSION,
+    HiveMessageType,
+    serialize,
+    deserialize,
+    create_hello,
+)
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+def _make_raw(version: int, msg_type: int, payload: dict) -> bytes:
+    """Build raw bytes with a specific envelope version."""
+    envelope = {
+        "version": version,
+        "type": msg_type,
+        "payload": payload,
+    }
+    return HIVE_MAGIC + json.dumps(envelope).encode("utf-8")
+
+
+# =============================================================================
+# VERSION RANGE ACCEPTANCE
+# =============================================================================
+
+class TestVersionTolerance:
+
+    def test_current_version_accepted(self):
+        """deserialize() accepts the current PROTOCOL_VERSION (v1)."""
+        data = _make_raw(PROTOCOL_VERSION, HiveMessageType.HELLO, {"pubkey": "abc"})
+        msg_type, payload = deserialize(data)
+        assert msg_type == HiveMessageType.HELLO
+        assert payload["pubkey"] == "abc"
+
+    def test_future_version_accepted(self):
+        """deserialize() accepts MAX_SUPPORTED_VERSION (v2) for rolling upgrades."""
+        data = _make_raw(MAX_SUPPORTED_VERSION, HiveMessageType.HELLO, {"pubkey": "xyz"})
+        msg_type, payload = deserialize(data)
+        assert msg_type == HiveMessageType.HELLO
+        assert payload["pubkey"] == "xyz"
+
+    def test_out_of_range_version_rejected(self):
+        """deserialize() rejects version 99 (not in SUPPORTED_VERSIONS)."""
+        data = _make_raw(99, HiveMessageType.HELLO, {"pubkey": "abc"})
+        msg_type, payload = deserialize(data)
+        assert msg_type is None
+        assert payload is None
+
+    def test_version_zero_rejected(self):
+        """deserialize() rejects version 0."""
+        data = _make_raw(0, HiveMessageType.HELLO, {"pubkey": "abc"})
+        msg_type, payload = deserialize(data)
+        assert msg_type is None
+
+    def test_negative_version_rejected(self):
+        """deserialize() rejects negative versions."""
+        data = _make_raw(-1, HiveMessageType.HELLO, {"pubkey": "abc"})
+        msg_type, payload = deserialize(data)
+        assert msg_type is None
+
+    def test_supported_versions_set(self):
+        """SUPPORTED_VERSIONS contains expected range."""
+        assert 1 in SUPPORTED_VERSIONS
+        assert 2 in SUPPORTED_VERSIONS
+        assert 0 not in SUPPORTED_VERSIONS
+        assert 3 not in SUPPORTED_VERSIONS
+
+
+# =============================================================================
+# ENVELOPE VERSION INJECTION
+# =============================================================================
+
+class TestEnvelopeVersionInjection:
+
+    def test_envelope_version_present_v1(self):
+        """Deserialized payload includes _envelope_version for v1."""
+        data = _make_raw(1, HiveMessageType.HELLO, {"pubkey": "a"})
+        _, payload = deserialize(data)
+        assert payload["_envelope_version"] == 1
+
+    def test_envelope_version_present_v2(self):
+        """Deserialized payload includes _envelope_version for v2."""
+        data = _make_raw(2, HiveMessageType.HELLO, {"pubkey": "a"})
+        _, payload = deserialize(data)
+        assert payload["_envelope_version"] == 2
+
+    def test_serialize_deserialize_roundtrip_preserves_version(self):
+        """Serialize with current version, deserialize gets _envelope_version."""
+        raw = serialize(HiveMessageType.HELLO, {"pubkey": "test"})
+        msg_type, payload = deserialize(raw)
+        assert msg_type == HiveMessageType.HELLO
+        assert payload["_envelope_version"] == PROTOCOL_VERSION
+
+
+# =============================================================================
+# create_hello() CHANGES
+# =============================================================================
+
+class TestCreateHelloVersions:
+
+    def test_hello_includes_supported_versions(self):
+        """create_hello() payload contains supported_versions list."""
+        raw = create_hello("02" + "a" * 64)
+        _, payload = deserialize(raw)
+        assert "supported_versions" in payload
+        assert sorted(payload["supported_versions"]) == sorted(SUPPORTED_VERSIONS)
+
+    def test_hello_backward_compatible(self):
+        """Old nodes ignore supported_versions - message still parses."""
+        raw = create_hello("02" + "b" * 64)
+        msg_type, payload = deserialize(raw)
+        assert msg_type == HiveMessageType.HELLO
+        assert payload["pubkey"] == "02" + "b" * 64
+        # protocol_version still present for backward compat
+        assert payload["protocol_version"] == PROTOCOL_VERSION
+
+    def test_old_hello_without_supported_versions_still_parses(self):
+        """A HELLO from an old node (no supported_versions) still deserializes."""
+        data = _make_raw(1, HiveMessageType.HELLO, {
+            "pubkey": "02" + "c" * 64,
+            "protocol_version": 1,
+        })
+        msg_type, payload = deserialize(data)
+        assert msg_type == HiveMessageType.HELLO
+        assert "supported_versions" not in payload  # old node doesn't send it
+
+
+# =============================================================================
+# PEER CAPABILITIES (Database)
+# =============================================================================
+
+class TestPeerCapabilities:
+
+    @pytest.fixture
+    def db(self, tmp_path):
+        from unittest.mock import Mock
+        from modules.database import HiveDatabase
+        mock_plugin = Mock()
+        mock_plugin.log = Mock()
+        db = HiveDatabase(str(tmp_path / "test.db"), mock_plugin)
+        db.initialize()
+        return db
+
+    def test_save_and_get_roundtrip(self, db):
+        """save_peer_capabilities / get_peer_capabilities round-trip."""
+        features = ["splice", "proto-v2"]
+        db.save_peer_capabilities("peer1", features)
+        caps = db.get_peer_capabilities("peer1")
+        assert caps is not None
+        assert caps["features"] == features
+        assert caps["max_protocol_version"] == 2
+
+    def test_get_nonexistent_peer(self, db):
+        """get_peer_capabilities returns None for unknown peer."""
+        assert db.get_peer_capabilities("unknown") is None
+
+    def test_get_max_protocol_version_default(self, db):
+        """get_peer_max_protocol_version returns 1 for unknown peer."""
+        assert db.get_peer_max_protocol_version("unknown") == 1
+
+    def test_get_max_protocol_version_saved(self, db):
+        """get_peer_max_protocol_version returns saved value."""
+        db.save_peer_capabilities("peer2", ["proto-v3", "splice"])
+        assert db.get_peer_max_protocol_version("peer2") == 3
+
+    def test_update_capabilities(self, db):
+        """Updating capabilities replaces old values."""
+        db.save_peer_capabilities("peer1", ["proto-v1"])
+        db.save_peer_capabilities("peer1", ["proto-v2", "splice"])
+        caps = db.get_peer_capabilities("peer1")
+        assert caps["max_protocol_version"] == 2
+        assert "splice" in caps["features"]
+
+    def test_invalid_features_rejected(self, db):
+        """Non-list features argument returns False."""
+        assert db.save_peer_capabilities("peer1", "not-a-list") is False


### PR DESCRIPTION
## Summary

- **Phase B (Version Tolerance):** `deserialize()` now accepts protocol versions 1-2 instead of hard-rejecting `!= 1`, preventing fleet partitions during rolling upgrades. `create_hello()` advertises `supported_versions`, peer capabilities are persisted from ATTEST manifests, and `proto-vN` is added to the handshake feature list.
- **Phase C (Deterministic Idempotency):** New `proto_events` table + `modules/idempotency.py` provide persistent dedup for 16 state-changing message families. 15 handlers now call `check_and_record()` before side effects, preventing double-processing after node restarts. The relay layer prefers deterministic `_event_id` over full-payload hashing.

### Files changed
| File | Changes |
|------|---------|
| `modules/protocol.py` | `SUPPORTED_VERSIONS` range; `deserialize()` version tolerance; `_envelope_version` injection; `create_hello()` advertises versions |
| `modules/handshake.py` | `proto-vN` in `_detect_features()` |
| `modules/database.py` | `peer_capabilities` + `proto_events` tables; 6 new methods |
| `modules/idempotency.py` | **New** — `EVENT_ID_FIELDS`, `generate_event_id()`, `check_and_record()` |
| `modules/relay.py` | `generate_msg_id()` prefers `_event_id`; excludes internal fields from hash |
| `cl-hive.py` | Version-aware logging; peer capabilities in `handle_attest`; idempotency checks in 15 handlers; cleanup in maintenance loop |

## Test plan
- [x] 39 new tests across `test_protocol_versioning.py` and `test_idempotency.py`
- [x] Full suite: 951 passed, 1 skipped, 0 failures — no regressions
- [ ] Verify rolling upgrade: v1-only node can still communicate with v1+v2 node
- [ ] Verify restart idempotency: restart node, replay queued messages, confirm no double side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)